### PR TITLE
Added new argument persistent, also updated readme and reformated cod…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ while not timeout.is_expired():
         t.reset()
 ```
 
+### Keep timeout even an app crash 
+
+You can set the optional attribute `persistent`
+- False 
+  - set by default 
+  - when the app crash, timeout will be set on the same value
+- True 
+  - `starting time` and `timeout` are stored in case of the app crash
+  - if the app can run only in specific time, for example from 2pm to 4pm
+
+```python
+import urpatimeout
+
+timeout = urpatimeout.Timeout(2 * 60 * 1000, persistent=True)
+while not timeout.is_expired():
+    do_something()
+```
+
 ### Optional past_safe Parameter
 
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,4 @@ mypy==0.812
 flake8==3.9.0
 pytest==6.2.3
 pytest-cov==2.11.1
+urpautils>=0.3.0

--- a/urpatimeout/__init__.py
+++ b/urpatimeout/__init__.py
@@ -1,3 +1,2 @@
+from .__about__ import __description__, __title__, __url__, __version__
 from .timeout import Timeout
-
-from .__about__ import __title__, __version__, __description__, __url__

--- a/urpatimeout/timeout.py
+++ b/urpatimeout/timeout.py
@@ -10,9 +10,16 @@ It helps you with setting up and measuring time limits:
 """
 
 from __future__ import annotations
+
 import datetime
+import os.path
 import time
 from typing import Union
+
+import urpautils
+
+START_STAMP_FILE = "start.txt"
+TIMEOUT_STAMP_FILE = "timeout.txt"
 
 
 class Timeout:
@@ -26,7 +33,9 @@ class Timeout:
         app.find_first(cf.name("Doe"), search_timeout)
     """
 
-    def __init__(self, timeout: Union[int, datetime.datetime], past_safe: bool = True) -> None:
+    def __init__(
+        self, timeout: Union[int, datetime.datetime], past_safe: bool = True, persistent: bool = False
+    ) -> None:
         """Initialization of instance of class Timeout.
 
         Args:
@@ -34,9 +43,12 @@ class Timeout:
                 Duration of time limit in ms or date.
             past_safe: bool
                 Set to False to ignore negative timeout value.
+            persistent: bool
+                Set to True to save timout in case of application crash
         """
         self.start = time.time_ns()
         self.past_safe = past_safe
+        self.persistent = persistent
         self.timeout = self._set_timeout(timeout)
 
     def __repr__(self) -> str:
@@ -53,7 +65,6 @@ class Timeout:
         Returns:
             int
         """
-
         if not isinstance(timeout, (int, datetime.datetime)):
             raise TypeError(f"timeout type must be an int or datetime.datetime, not a '{type(timeout)}'!")
         if isinstance(timeout, datetime.datetime):
@@ -63,6 +74,12 @@ class Timeout:
                 "timeout value must be a positive int or a datetime.datetime in the future"
                 " or consider set a past_safe parameter to False!"
             )
+        if self.persistent:
+            if os.path.isfile(TIMEOUT_STAMP_FILE) and os.path.isfile(START_STAMP_FILE):
+                timeout = int(urpautils.read_txt_file(TIMEOUT_STAMP_FILE))
+                self.start = int(urpautils.read_txt_file(START_STAMP_FILE))
+            urpautils.write_txt_file(TIMEOUT_STAMP_FILE, str(timeout), mode="w")
+            urpautils.write_txt_file(START_STAMP_FILE, str(self.start), mode="w")
         return timeout
 
     def elapsed(self) -> int:
@@ -87,7 +104,12 @@ class Timeout:
         Returns:
             bool
         """
-        return self.remaining() <= 0
+        print(self.remaining())
+        if self.remaining() <= 0:
+            urpautils.remove(START_STAMP_FILE)
+            urpautils.remove(TIMEOUT_STAMP_FILE)
+            return True
+        return False
 
     def reset(self, timeout: Union[None, int, datetime.datetime] = None) -> None:
         """Resets the starting time of the timeout.
@@ -96,6 +118,8 @@ class Timeout:
             timeout: None, int or datetime.datetime
                 Omit to keep the time limit or set a new one.
         """
+        urpautils.remove(START_STAMP_FILE)
+        urpautils.remove(TIMEOUT_STAMP_FILE)
         self.start = time.time_ns()
         if timeout is not None:
             self.timeout = self._set_timeout(timeout)


### PR DESCRIPTION
Added a new optional argument **persistent** to the Timeout class - it is used in case of the app crash.
It may be handy, if the app can run, for example, only from 2pm to 4pm.
After reboot, _set_timeout() method will detect **start time** and **duration** from temporary files  for which it should run and use this information instead of given.
User can always use reset() method to use new start time and duration.
Also updated README.md.

Closes #20 